### PR TITLE
Switch pdepend arguments order in runmetrics binary

### DIFF
--- a/bin/runmetrics
+++ b/bin/runmetrics
@@ -46,6 +46,6 @@ foreach ($testSuites as $suite) {
     $reportsDir = $suite .'/reports';
     $fileCopier->createEmptyDirectory($reportsDir);
 
-    passthru("$pDepend --summary-xml=$reportsDir/pdepend.xml --ignore=vendor,tests,out $suite/../ $arguments");
+    passthru("$pDepend --summary-xml=$reportsDir/pdepend.xml --ignore=vendor,tests,out $arguments $suite/../");
     passthru("$mcMetrics $reportsDir/pdepend.xml > $reportsDir/metrics.txt");
 }


### PR DESCRIPTION
Possible solution for fixing issue: https://github.com/OXID-eSales/testing_library/issues/9