### PR TITLE
Skip creating dumb of db if config option for restore is set to false

### DIFF
--- a/library/oxAcceptanceTestCase.php
+++ b/library/oxAcceptanceTestCase.php
@@ -91,6 +91,12 @@ class oxAcceptanceTestCase extends oxMinkWrapper
     private static $moduleLoader = null;
 
     /**
+     * Configuation object for test parameters
+     * @var oxTestConfig
+     */
+    private $oTestConfig;
+
+    /**
      * Constructs a test case with the given name.
      *
      * @param string $name
@@ -1577,10 +1583,12 @@ class oxAcceptanceTestCase extends oxMinkWrapper
      */
     public function dumpDB($sTmpPrefix = null)
     {
-        $oServiceCaller = new oxServiceCaller($this->getTestConfig());
-        $oServiceCaller->setParameter('dumpDB', true);
-        $oServiceCaller->setParameter('dump-prefix', $sTmpPrefix);
-        $oServiceCaller->callService('ShopPreparation', 1);
+        if ($this->oTestConfig->shouldRestoreAfterAcceptanceTests()) {
+            $oServiceCaller = new oxServiceCaller($this->getTestConfig());
+            $oServiceCaller->setParameter('dumpDB', true);
+            $oServiceCaller->setParameter('dump-prefix', $sTmpPrefix);
+            $oServiceCaller->callService('ShopPreparation', 1);
+        }
     }
 
     /**
@@ -1594,10 +1602,13 @@ class oxAcceptanceTestCase extends oxMinkWrapper
      */
     public function restoreDB($sTmpPrefix = null)
     {
-        $oServiceCaller = new oxServiceCaller($this->getTestConfig());
-        $oServiceCaller->setParameter('restoreDB', true);
-        $oServiceCaller->setParameter('dump-prefix', $sTmpPrefix);
-        $oServiceCaller->callService('ShopPreparation', 1);
+
+        if ($this->oTestConfig->shouldRestoreAfterAcceptanceTests()) {
+            $oServiceCaller = new oxServiceCaller($this->getTestConfig());
+            $oServiceCaller->setParameter('restoreDB', true);
+            $oServiceCaller->setParameter('dump-prefix', $sTmpPrefix);
+            $oServiceCaller->callService('ShopPreparation', 1);
+        }
     }
 
     /**

--- a/library/oxBaseTestCase.php
+++ b/library/oxBaseTestCase.php
@@ -16,9 +16,20 @@ class oxBaseTestCase extends PHPUnit_Framework_TestCase
      */
     public function getTestConfig()
     {
+        return self::getStaticTestConfig();
+    }
+
+    /**
+     * Returns test configuration.
+     *
+     * @return oxTestConfig
+     */
+    public static function getStaticTestConfig()
+    {
         if (is_null(self::$testConfig)) {
             self::$testConfig = new oxTestConfig();
         }
+        
         return self::$testConfig;
     }
 

--- a/library/oxTestConfig.php
+++ b/library/oxTestConfig.php
@@ -316,6 +316,24 @@ class oxTestConfig
     }
 
     /**
+     * Whether to dumb and restore the db when running the acceptance tests
+     * @return bool|null
+     */
+    public function shouldRestoreAfterAcceptanceTests()
+    {
+        return (bool)$this->getValue('restore_after_acceptance_tests');
+    }
+
+    /**
+     * Whether to dumb and restore the db after all tests finished in a test suite
+     * @return bool|null
+     */
+    public function shouldRestoreAfterTests()
+    {
+        return (bool)$this->getValue('restore_after_tests');
+    }
+
+    /**
      * Whether to activate all modules when running tests.
      *
      * @return bool

--- a/library/oxUnitTestCase.php
+++ b/library/oxUnitTestCase.php
@@ -97,7 +97,9 @@ class oxUnitTestCase extends oxBaseTestCase
         }
         oxRegistry::set("oxUtilsDate", new modOxUtilsDate());
 
-        $this->backupDatabase();
+        if ($testConfig->shouldRestoreShopAfterTestsSuite()) {
+            $this->backupDatabase();
+        }
 
         oxRegistry::getUtils()->commitFileCache();
 
@@ -179,8 +181,11 @@ class oxUnitTestCase extends oxBaseTestCase
     public static function tearDownAfterClass()
     {
         self::getShopStateBackup()->resetStaticVariables();
-        $dbRestore = self::_getDbRestore();
-        $dbRestore->restoreDB();
+        $testConfig = self::getStaticTestConfig();
+        if ($testConfig->shouldRestoreShopAfterTestsSuite()) {
+            $dbRestore = self::_getDbRestore();
+            $dbRestore->restoreDB();
+        }
     }
 
     /**

--- a/library/oxUnitTestCase.php
+++ b/library/oxUnitTestCase.php
@@ -97,7 +97,7 @@ class oxUnitTestCase extends oxBaseTestCase
         }
         oxRegistry::set("oxUtilsDate", new modOxUtilsDate());
 
-        if ($testConfig->shouldRestoreShopAfterTestsSuite()) {
+        if ($testConfig->shouldRestoreAfterTests()) {
             $this->backupDatabase();
         }
 
@@ -182,7 +182,7 @@ class oxUnitTestCase extends oxBaseTestCase
     {
         self::getShopStateBackup()->resetStaticVariables();
         $testConfig = self::getStaticTestConfig();
-        if ($testConfig->shouldRestoreShopAfterTestsSuite()) {
+        if ($testConfig->shouldRestoreAfterTests()) {
             $dbRestore = self::_getDbRestore();
             $dbRestore->restoreDB();
         }
@@ -503,7 +503,7 @@ class oxUnitTestCase extends oxBaseTestCase
             }
         }
 
-        if ($tablesForCleanup = $this->getTablesForCleanup()) {
+        if ($tablesForCleanup = $this->getTablesForCleanup() && $this->getTestConfig()->shouldRestoreAfterTests()) {
             $dbRestore = $this->_getDbRestore();
             foreach ($tablesForCleanup as $sTable) {
                 $dbRestore->restoreTable($sTable);

--- a/test_config.yml.dist
+++ b/test_config.yml.dist
@@ -39,6 +39,12 @@ optional_parameters:
     # Whether to restore shop data after running all tests. If this is set to false, shop will be left with tests data added on it.
     restore_shop_after_tests_suite: false
 
+    # Whether to dump and restore the database when running the acceptance tests.
+    restore_after_acceptance_tests: true
+
+    # Whether to dump and restore the database after all tests are finished in a testsuite
+    restore_after_tests: true
+
     # If php has no write access to /tmp folder, provide alternative temp folder for tests.
     tmp_path: /tmp/oxid_test_library/
 


### PR DESCRIPTION
If the option restore_shop_after_tests_suite is set to false then do not create a db dumb of the entire shop because it is not used anyway. This is helpful when using an own concept of how test data is being used in a test case for example when developing new modules.
