### PR TITLE
add method to switch shop configuration and reload it with diff id

### DIFF
--- a/library/oxUnitTestCase.php
+++ b/library/oxUnitTestCase.php
@@ -312,6 +312,18 @@ class oxUnitTestCase extends oxBaseTestCase
     }
 
     /**
+     * Reset the shop configuration and reload it with new shop id
+     * @param integer $iShopId
+     */
+    public function setShopConfig($iShopId)
+    {
+        $oConfig = oxRegistry::getConfig();
+        $oConfig->setShopId($iShopid);
+        $oConfig->setConfigParam('_blInit', false);
+        $oConfig->init();
+    }
+
+    /**
      * Set static time value for testing.
      *
      * @param int $time


### PR DESCRIPTION
With this pull request I want to introduce a new method helper which makes it possible to switch the shop configuration on the fly during a Test Case. This is helpful when you have a multishop environment with different configurations per shop. You can then configure the shop via backend and load the configuration instead of setting the different config options via php code in the Test Case. 