### PR TITLE
replace env with php in shebang

### DIFF
--- a/bin/reset-shop
+++ b/bin/reset-shop
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php
 <?php
 /**
  * Copyright © OXID eSales AG. All rights reserved.

--- a/bin/runmetrics
+++ b/bin/runmetrics
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php
 <?php
 /**
  * Copyright © OXID eSales AG. All rights reserved.

--- a/bin/runtests
+++ b/bin/runtests
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php
 <?php
 /**
  * Copyright © OXID eSales AG. All rights reserved.

--- a/bin/runtests-coverage
+++ b/bin/runtests-coverage
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php
 <?php
 /**
  * Copyright © OXID eSales AG. All rights reserved.

--- a/bin/runtests-selenium
+++ b/bin/runtests-selenium
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!/usr/bin/php
 <?php
 /**
  * Copyright © OXID eSales AG. All rights reserved.


### PR DESCRIPTION
Changing the path of the PHP interpreter to /usr/bin/php instead of using /usr/bin/env for several reasons:

- we had the issue that if you use env, you mask certain errors on calling the script. Namely when calling e.g. vendor/bin/runtests, the output was:

vagrant@zeppelin:/var/www/oxideshop$ vendor/bin/runtests
: No such file or directory

while with php:
vagrant@zeppelin:/var/www/oxideshop$ php vendor/bin/runtests
PHP Warning:  require_once(/var/www/oxideshop/repositories/testing_library/vendor/autoload.php): failed to open stream: No such file or directory in /var/www/oxideshop/repositories/testing_library/base.php on line 24
PHP Stack trace:
PHP   1. {main}() /var/www/oxideshop/repositories/testing_library/bin/runtests:0
PHP   2. require_once() /var/www/oxideshop/repositories/testing_library/bin/runtests:8

(The issue actually was DOS line endings in the file but env masked that error)

- https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my contains also very good reasons not to use it (and some to do it). One is a security consideration as the environment can be manipulated a lot easier by an attacker than the interpreter in an absolute path.

- it is always still possible to run `php vendor/bin/runtests` if he wants an environment dependant interpreter location

of course this is a non backwards-compatible change