### PR TITLE
bugfix: renamed $_aTestSuites to $testSuites

### DIFF
--- a/AllTestsIntegration.php
+++ b/AllTestsIntegration.php
@@ -13,5 +13,5 @@ class AllTestsIntegration extends AllTestsRunner
 {
 
     /** @var array Default test suites */
-    protected static $_aTestSuites = array('integration', 'Integration');
+    protected static $testSuites = array('integration', 'Integration');
 }


### PR DESCRIPTION
It's currently not possible to run only Integration-Tests like this:
```
$ TEST_SUITE=$(pwd)/source/modules/path/to/Tests/ vendor/bin/runtests AllTestsIntegration
```