### PR TITLE
Add array option to phpdoc for setRequestParameter function

### DIFF
--- a/library/UnitTestCase.php
+++ b/library/UnitTestCase.php
@@ -246,7 +246,7 @@ abstract class UnitTestCase extends BaseTestCase
      * Sets parameter to POST.
      *
      * @param string $paramName
-     * @param string $paramValue
+     * @param string|array $paramValue
      */
     public function setRequestParameter($paramName, $paramValue)
     {


### PR DESCRIPTION
Adding the option in PHPDOC to use an array for the $paramValue in the setRequestParameter function.
Reason is that sometimes you want to test a Post of form data which is send
like editval[]. In this case I pass an array for the paramValue which is working
as expected but currently creating warnings because the PHPDOC is set to string only.