### PR TITLE
Update mikey179/vfsstream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.2",
         "phpunit/phpunit": "^9.1.1",
         "pdepend/pdepend": "2.7.0",
-        "mikey179/vfsstream": "^1",
+        "mikey179/vfsstream": "~1.6.8",
         "behat/mink": "~1.5.0",
         "oxid-esales/mink-selenium-driver": "~v1.1.2",
         "symfony/yaml": "^5.0.4",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.2",
         "phpunit/phpunit": "^9.1.1",
         "pdepend/pdepend": "2.7.0",
-        "mikey179/vfsstream": "~1.4.0",
+        "mikey179/vfsstream": "^1",
         "behat/mink": "~1.5.0",
         "oxid-esales/mink-selenium-driver": "~v1.1.2",
         "symfony/yaml": "^5.0.4",


### PR DESCRIPTION
Hey there :vulcan_salute:

`mikey179/vfsstream` in version `v1.4.0` as we use it has been released in September 2014 and can savely considered outdated :stuck_out_tongue_winking_eye:.
Additionally there are backported fixes for PHP 7.4 compatibility in version `v1.6.8` which we need in order to get our pipeline :green_heart:

/Flo