### PR TITLE
Fix chmod syntax

### DIFF
--- a/library/Services/Library/Cache.php
+++ b/library/Services/Library/Cache.php
@@ -44,7 +44,9 @@ class Cache
     public function clearTemporaryDirectory()
     {
         if ($sCompileDir = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('sCompileDir')) {
-            CliExecutor::executeCommand("sudo chmod -R 777 $sCompileDir");
+            if (!is_writable($sCompileDir)) {
+                CliExecutor::executeCommand("sudo chmod -R 777 $sCompileDir");
+            }
             $this->removeTemporaryDirectory($sCompileDir, false);
         }
     }

--- a/library/Services/Library/Cache.php
+++ b/library/Services/Library/Cache.php
@@ -44,7 +44,7 @@ class Cache
     public function clearTemporaryDirectory()
     {
         if ($sCompileDir = \OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ConfigFile::class)->getVar('sCompileDir')) {
-            CliExecutor::executeCommand("sudo chmod 777 -R $sCompileDir");
+            CliExecutor::executeCommand("sudo chmod -R 777 $sCompileDir");
             $this->removeTemporaryDirectory($sCompileDir, false);
         }
     }


### PR DESCRIPTION
`sudo chmod 777 -R $sCompileDir` produces `chmod: -R: No such file or directory` using `zsh` on `Catalina 10.15.6`.
The library is unusable in the current state.

The command also should only be executed, if the permissions aren't correct. Mac users currently have to enter their password every time they run a test suite.