### PR TITLE
Fix duplicate module activation

### DIFF
--- a/library/ModuleLoader.php
+++ b/library/ModuleLoader.php
@@ -73,6 +73,9 @@ class ModuleLoader
     public function installModule($modulePath)
     {
         $module = $this->loadModule($modulePath);
+        if ($module->isActive()) {
+            return;
+        }
 
         $moduleCache = new ModuleCache($module);
         $moduleInstaller = new ModuleInstaller($moduleCache);

--- a/library/Services/ModuleInstaller/ModuleInstaller.php
+++ b/library/Services/ModuleInstaller/ModuleInstaller.php
@@ -83,6 +83,9 @@ class ModuleInstaller implements ShopServiceInterface
     public function installModule($modulePath)
     {
         $module = $this->loadModule($modulePath);
+        if ($module->isActive()) {
+            return;
+        }
 
         $moduleCache = oxNew(\OxidEsales\Eshop\Core\Module\ModuleCache::class, $module);
         $moduleInstaller = oxNew(\OxidEsales\Eshop\Core\Module\ModuleInstaller::class, $moduleCache);


### PR DESCRIPTION
**Steps to reproduce:**
1. Manually activate module
2. Run tests

Currently produces:
`PHP Fatal error:  Uncaught OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSetupException: Module with id "my_module_id" is already active. in /Users/Shared/development/webshop/oxid-current/vendor/oxid-esales/oxideshop-ce/source/Internal/Framework/Module/Setup/Service/ModuleActivationService.php:89`