### PR TITLE
Fix world-writable default permissions for /tmp folder

### DIFF
--- a/library/Services/Library/DatabaseDefaultsFileGenerator.php
+++ b/library/Services/Library/DatabaseDefaultsFileGenerator.php
@@ -38,6 +38,7 @@ class DatabaseDefaultsFileGenerator
             . "\n";
         fwrite($resource, $fileContents);
         fclose($resource);
+        chmod($file, 0750);
         return $file;
     }
 }


### PR DESCRIPTION
Fix world-writable default permissions for /tmp folder used for generating MySQL config. MySQL ignores those files now.