### PR TITLE
Use strtolower only for non namespace classes

### DIFF
--- a/library/UnitTestCase.php
+++ b/library/UnitTestCase.php
@@ -682,7 +682,10 @@ abstract class UnitTestCase extends BaseTestCase
      */
     public function getProxyClassName($superClassName)
     {
-        $superClassName = \OxidEsales\Eshop\Core\Registry::get(UtilsObject::class)->getClassName(strtolower($superClassName));
+        if (strpos($superClassName,'\\')===false) {
+            $superClassName = strtolower($superClassName);
+        }
+        $superClassName = Registry::get(UtilsObject::class)->getClassName($superClassName);
         $escapedSuperClassName = str_replace('\\', '_', $superClassName);
         $proxyClassName = "{$escapedSuperClassName}Proxy";
 


### PR DESCRIPTION
The method getProxyClassName creates a new class via the eval method.
The proxy class extends the class which is passed via parameter.
But the extended class is modified with strtolower.
That's a problem if you use namespaces and autoload.

I always got an error if I use the getProxyClassName and classes with namespace.
E.g. 
`$this
            ->getMockBuilder($this->getProxyClassName(\OxidEsales\Eshop\Core\UtilsCount::class))
            ->disableOriginalConstructor()
            ->getMock();`
`Error: Class 'oxidesales\eshop\core\utilscount' not found`

However if you load the class before the mock, the autoload loads the class and the mock can be build. (Tested on my MacOSX with vagrant)
`oxNew(\OxidEsales\Eshop\Core\UtilsCount::class);
        $this
            ->getMockBuilder($this->getProxyClassName(\OxidEsales\Eshop\Core\UtilsCount::class))
            ->disableOriginalConstructor()
            ->getMock();`

So I just simply check if there is a backslash in the classname and if there is no one, the class name could be modified.